### PR TITLE
Add Key Up/Down and Tempo +/- mapping on Page A

### DIFF
--- a/Novation-Launchpad-Mini-scripts.js
+++ b/Novation-Launchpad-Mini-scripts.js
@@ -294,6 +294,33 @@ function FFBK(deck, ctrl, ffbk) {
   return that;
 }
 
+function ControlKey(deck, ctrl, action, color_off, color_on) {
+  var that = new Key();
+  that.deck = deck;
+  that.group = "[" + ctrl + deck + "]";
+  that.setColor(color_off);
+
+  that.setled = function() {
+      if (this.pressed) {
+          this.setColor(color_on);
+      } else {
+          this.setColor(color_off);
+      }
+  }
+
+  that.setled()
+
+  that.callback = function() {
+    if (this.pressed) {
+      engine.setValue(this.group, action, 1);
+    } else {
+      engine.setValue(this.group, action, 0);
+    }
+    that.setled()
+  }
+  return that;
+}
+
 function PlayKey(ctrl, deck) {
     var that = new Key();
     that.group = "[" + ctrl + deck + "]";
@@ -642,6 +669,12 @@ NLM.init = function()
               NLM.setupBtn(page,0,0, PlayKey("Channel", deck));
               // PFL
               NLM.setupBtn(page,1,0, TooglePfl("Channel", deck));
+              // KEY
+              NLM.setupBtn(page,2,0, ControlKey(deck, "Channel", "pitch_down", "lo_amber", "hi_red"));
+              NLM.setupBtn(page,3,0, ControlKey(deck, "Channel", "pitch_up", "lo_amber", "hi_red"));
+              // TEMPO
+              NLM.setupBtn(page,0,1, ControlKey(deck, "Channel", "rate_perm_down", "lo_yellow", "hi_red"));
+              NLM.setupBtn(page,1,1, ControlKey(deck, "Channel", "rate_perm_up", "lo_yellow", "hi_red"));
               // FAST FORWARD
               NLM.setupBtn(page,3,1, FFBK(deck, "Channel", "fwd"));
               // FAST REWIND
@@ -680,6 +713,12 @@ NLM.init = function()
             NLM.setupBtn(page,0,4, PlayKey("Channel", deck));
             // PFL
             NLM.setupBtn(page,1,4, TooglePfl("Channel", deck));
+            // KEY
+            NLM.setupBtn(page,2,4, ControlKey(deck, "Channel", "pitch_down", "lo_amber", "hi_red"));
+            NLM.setupBtn(page,3,4, ControlKey(deck, "Channel", "pitch_up", "lo_amber", "hi_red"));
+            // TEMPO
+            NLM.setupBtn(page,0,5, ControlKey(deck, "Channel", "rate_perm_down", "lo_yellow", "hi_red"));
+            NLM.setupBtn(page,1,5, ControlKey(deck, "Channel", "rate_perm_up", "lo_yellow", "hi_red"));
             // FAST FORWARD
             NLM.setupBtn(page,3,5, FFBK(deck, "Channel", "fwd"));
             // FAST REWIND

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Choose a page by press buttons A to H on the right of your Launchpad Mini
   * 14 - Hot Cue 3
   * 15 - Hot Cue 4
   * 16 - Progress of the song (this is two rows wide)
+  * 17 - Key Down (Button between PFL and Loop)
+  * 18 - Key Up (Button between PFL and Loop)
+  * 19 - Tempo Down (Button below Play/Pause)
+  * 20 - Tempo Up (Button below PFL)
   
   ![PageA](https://i.imgur.com/d2YZDc3.jpg)
 


### PR DESCRIPTION
This commit adds a new `ControlKey` helper function to easily trigger momentary actions and use it to map Pitch Down, Pitch Up, Tempo Down, and Tempo Up on the 4 empty slots for Decks 1 and 2 on Page A. The README is also updated with these mapping additions.

---
*PR created automatically by Jules for task [18348008978514748427](https://jules.google.com/task/18348008978514748427) started by @jdsilvaa*